### PR TITLE
Add `./main` at the `command` section in `furiosa-metrics-exporter` template

### DIFF
--- a/charts/furiosa-metrics-exporter/Chart.yaml
+++ b/charts/furiosa-metrics-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: furiosa-metrics-exporter
 description: A Helm chart for furiosa-metrics-exporter
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.1.0"

--- a/charts/furiosa-metrics-exporter/templates/daemonset.yaml
+++ b/charts/furiosa-metrics-exporter/templates/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
       containers:
         - name: {{ include "furiosa-metrics-exporter.name" . }}
           image: {{ .Values.daemonSet.image.repository | default "docker.io/furiosaai/furiosa-metrics-exporter" }}:{{ .Values.daemonSet.image.tag | default "latest" }}
+          command:
+            - ./main
           args:
             - --port=$(PORT)
             - --interval=$(INTERVAL)


### PR DESCRIPTION
### One line PR Description
Add `./main` at the `command` section in `furiosa-metrics-exporter` template.
- Without this, Pod will not be executed due to executable not found error.

### What type of PR is this?
/kind bug

### Special notes for reviewer
