### PR TITLE
Fix `furiosa-device-plugin` Helm chart to follow the correct config structure

### DIFF
--- a/charts/furiosa-device-plugin/Chart.yaml
+++ b/charts/furiosa-device-plugin/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: furiosa-device-plugin
 description: A Helm chart for furiosa-device-plugin
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.1.0"
 kubeVersion: ">= 1.20.0-0"

--- a/charts/furiosa-device-plugin/templates/configmap.yaml
+++ b/charts/furiosa-device-plugin/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Values.namespace | default "kube-system" }}
 data:
   config.yaml: |
-    resourceStrategy: {{ .Values.config.resourceStrategy | default "generic" }}
+    partitioning: {{ .Values.config.partitioning | default "generic" }}
     debugMode: {{ .Values.config.debugMode | default "false" }}
-    disabledDeviceUUIDListMap:
-{{ toYaml (default dict .Values.config.disabledDeviceUUIDListMap) | indent 6 }}
+    disabledDeviceUUIDs:
+{{ toYaml (default dict .Values.config.disabledDeviceUUIDs) | indent 6 }}

--- a/charts/furiosa-device-plugin/templates/configmap.yaml
+++ b/charts/furiosa-device-plugin/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Values.namespace | default "kube-system" }}
 data:
   config.yaml: |
-    partitioning: {{ .Values.config.partitioning | default "generic" }}
+    partitioning: {{ .Values.config.partitioning | default "none" }}
     debugMode: {{ .Values.config.debugMode | default "false" }}
     disabledDeviceUUIDs:
 {{ toYaml (default dict .Values.config.disabledDeviceUUIDs) | indent 6 }}

--- a/charts/furiosa-device-plugin/values.yaml
+++ b/charts/furiosa-device-plugin/values.yaml
@@ -32,8 +32,8 @@ daemonSet:
    # - name: imagepullsecret
 
 config:
-  resourceStrategy: generic
+  partitioning: none
   debugMode: false
-  disabledDeviceUUIDListMap:
+  disabledDeviceUUIDs:
    # node:
    #   - "uuid"


### PR DESCRIPTION
### One line PR Description
- resolve: #20 

Through this PR, `furiosa-device-plugin` will follow the correct configuration structure of it.

### What type of PR is this?
/kind bug

### Special notes for reviewer
