### PR TITLE
Update existing Helm Chart to `2026.1.1`

### DIFF
--- a/.github/workflows/examine_pr_changes.yml
+++ b/.github/workflows/examine_pr_changes.yml
@@ -43,7 +43,8 @@ jobs:
           - v1.32.11
           - v1.33.7
           - v1.34.3
-          - v1.35.0
+          - v1.35.5
+          - v1.36.1
     steps:
       - name: checkout
         uses: actions/checkout@v6

--- a/.github/workflows/kind_config/kind_v1.35.0.yaml
+++ b/.github/workflows/kind_config/kind_v1.35.0.yaml
@@ -1,7 +1,0 @@
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-  - role: control-plane
-    image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
-  - role: worker
-    image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661

--- a/.github/workflows/kind_config/kind_v1.35.5.yaml
+++ b/.github/workflows/kind_config/kind_v1.35.5.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95
+  - role: worker
+    image: kindest/node:v1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95

--- a/.github/workflows/kind_config/kind_v1.36.1.yaml
+++ b/.github/workflows/kind_config/kind_v1.36.1.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+  - role: worker
+    image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5

--- a/charts/furiosa-device-plugin/Chart.yaml
+++ b/charts/furiosa-device-plugin/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: furiosa-device-plugin
 description: A Helm chart for furiosa-device-plugin
 type: application
-version: 2026.1.0
-appVersion: 2026.1.0
+version: 2026.1.1
+appVersion: 2026.1.1
 kubeVersion: ">= 1.20.0-0"

--- a/charts/furiosa-dra-driver/Chart.yaml
+++ b/charts/furiosa-dra-driver/Chart.yaml
@@ -3,5 +3,5 @@ name: furiosa-dra-driver
 description: A Helm chart for furiosa-dra-driver
 type: application
 version: 2026.1.1
-appVersion: 2026.1.0
+appVersion: 2026.1.1
 kubeVersion: ">= 1.34.0"

--- a/charts/furiosa-dra-driver/Chart.yaml
+++ b/charts/furiosa-dra-driver/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: furiosa-dra-driver
 description: A Helm chart for furiosa-dra-driver
 type: application
-version: 2026.1.1
+version: 2026.1.2
 appVersion: 2026.1.1
 kubeVersion: ">= 1.34.0"

--- a/charts/furiosa-dra-driver/Chart.yaml
+++ b/charts/furiosa-dra-driver/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: furiosa-dra-driver
 description: A Helm chart for furiosa-dra-driver
 type: application
-version: 2026.1.2
+version: 2026.1.1
 appVersion: 2026.1.1
 kubeVersion: ">= 1.34.0"

--- a/charts/furiosa-feature-discovery/Chart.yaml
+++ b/charts/furiosa-feature-discovery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: furiosa-feature-discovery
 description: A Helm chart for furiosa-feature-discovery
 type: application
-version: 2026.1.0
-appVersion: 2026.1.0
+version: 2026.1.1
+appVersion: 2026.1.1
 
 dependencies:
   - name: node-feature-discovery

--- a/charts/furiosa-metrics-exporter/Chart.yaml
+++ b/charts/furiosa-metrics-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: furiosa-metrics-exporter
 description: A Helm chart for furiosa-metrics-exporter
 type: application
-version: 2026.1.0
-appVersion: 2026.1.0
+version: 2026.1.1
+appVersion: 2026.1.1

--- a/charts/furiosa-npu-operator/Chart.yaml
+++ b/charts/furiosa-npu-operator/Chart.yaml
@@ -3,8 +3,8 @@ name: furiosa-npu-operator
 description: A Helm chart for `furiosa-npu-operator`
 type: application
 
-version: 2026.1.0
-appVersion: 2026.1.0
+version: 2026.1.1
+appVersion: 2026.1.1
 
 dependencies:
   - name: node-feature-discovery


### PR DESCRIPTION
### One line PR Description

Update existing Helm Chart to `2026.1.1`. Below charts are targeted:
- `furiosa-device-plugin`
- `furiosa-dra-driver`
- `furiosa-feature-discovery`
- `furiosa-metrics-exporter`
- `furiosa-npu-operator`

From `2026.1.1`, our container image supports multi-arch (both `linux/amd64` and `linux/arm64`)

### What type of PR is this?
/kind devops

### Special notes for reviewer
